### PR TITLE
Image attachment feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,69 @@ for ( var i = 0, l = users.length; i < l; i++ ) {
   })
 }
 ```
+
+### Sending a message with an image attachment
+
+```javascript
+
+var fs = require( 'fs' )
+var Push = require( 'pushover-notifications' )
+
+var p = new Push( {
+  user: process.env['PUSHOVER_USER'],
+  token: process.env['PUSHOVER_TOKEN'],
+})
+
+var msg = {
+  message: 'omg node test',	// required
+  title: "Well - this is fantastic - an attachment",
+  sound: 'magic',
+  device: 'devicename',
+  attachment: fs.createReadStream('path/to/image.jpg'),
+  priority: 1
+}
+
+p.send( msg, function( err, result ) {
+  if ( err ) {
+    throw err
+  }
+
+  console.log( result )
+})
+```
+
+### Sending a message with an image attachment from a Buffer
+
+```javascript
+
+var fs = require( 'fs' )
+var Push = require( 'pushover-notifications' )
+
+var p = new Push( {
+  user: process.env['PUSHOVER_USER'],
+  token: process.env['PUSHOVER_TOKEN'],
+})
+
+// data is a Buffer object holding contents of image.jpg
+fs.readFile('path/to/image.jpg', function (err, data) {
+  if (err) throw err;
+
+  var msg = {
+    message: 'omg node test',	// required
+    title: "Well - this is fantastic - an attachment from a buffer",
+    sound: 'magic',
+    device: 'devicename',
+    attachment: data
+    priority: 1
+  }
+
+  p.send( msg, function( err, result ) {
+    if ( err ) {
+      throw err
+    }
+
+    console.log( result )
+  })
+})
+
+```

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -120,21 +120,21 @@ Pushover.prototype.send = function (obj, fn) {
 
   obj = setDefaults(obj)
 
-  form.append('token',self.token || obj.token)
-  form.append('user',self.user || obj.user)
+  form.append('token', self.token || obj.token)
+  form.append('user', self.user || obj.user)
 
-	if('attachment' in obj && obj.attachment instanceof Buffer) {
-		// Sending a file from a buffer
-		// https://stackoverflow.com/a/43914175
-		form.append('attachment',obj.attachment,{filename: 'filename'})
+  if ('attachment' in obj && obj.attachment instanceof Buffer) {
+    // Sending a file from a buffer
+    // https://stackoverflow.com/a/43914175
+    form.append('attachment', obj.attachment, {filename: 'filename'})
     delete obj.attachment
-	}
+  }
   var p
   for (p in obj) {
-    form.append(p,obj[p])
+    form.append(p, obj[p])
   }
 
-	o.headers = form.getHeaders()
+  o.headers = form.getHeaders()
 
   var httpOpts = self.httpOptions || {}
   if (httpOpts) {
@@ -152,38 +152,33 @@ Pushover.prototype.send = function (obj, fn) {
     o.protocol = proxy.protocol
   }
 
-  form.submit(o,function(err,res) {
-    if(err) {
-	    if (fn) {
-		    fn(err)
-	    }
-	    // In the tests the "end" event did not get emitted if  "error" was emitted,
-	    // but to be sure that the callback is not get called twice, null the callback function
-	    fn = null
+  form.submit(o, function (err, res) {
+    if (err) {
+      if (fn) {
+        fn(err)
+      }
+      // In the tests the "end" event did not get emitted if  "error" was emitted,
+      // but to be sure that the callback is not get called twice, null the callback function
+      fn = null
     }
 
-	  if (self.debug) {
-		  console.log(res.statusCode)
-	  }
+    if (self.debug) {
+      console.log(res.statusCode)
+    }
 
-	  var data = ''
-	  res.on('end', function () {
-		  self.errors(data, res)
-		  if (fn) {
-			  fn(err, data, res)
-		  }
-	  })
+    var data = ''
+    res.on('end', function () {
+      self.errors(data, res)
+      if (fn) {
+        fn(err, data, res)
+      }
+    })
 
-	  res.on('data', function (chunk) {
-		  data += chunk
-	  })
+    res.on('data', function (chunk) {
+      data += chunk
+    })
   })
 
-
-
-  // if (self.debug) {
-  //   console.log(form.replace(self.token, 'XXXXX').replace(self.user, 'XXXXX'))
-  // }
 }
 
 exports = module.exports = Pushover

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -3,6 +3,7 @@ var http = require('http')
 var url = require('url')
 var qs = require('querystring')
 var pUrl = 'https://api.pushover.net/1/messages.json'
+var FormData = require('form-data')
 
 function setDefaults (o) {
   var def = [
@@ -113,26 +114,21 @@ Pushover.prototype.updateSounds = function () {
 Pushover.prototype.send = function (obj, fn) {
   var self = this
   var o = url.parse(pUrl)
+  var form = new FormData()
   var proxy
   o.method = 'POST'
 
   obj = setDefaults(obj)
 
-  var reqString = {
-    token: self.token || obj.token,
-    user: self.user || obj.user
-  }
+  form.append('token',self.token || obj.token)
+  form.append('user',self.user || obj.user)
 
   var p
   for (p in obj) {
-    reqString[ p ] = obj[p]
+    form.append(p,obj[p])
   }
 
-  reqString = qs.stringify(reqString)
-
-  o.headers = {
-    'Content-Length': reqString.length
-  }
+	o.headers = form.getHeaders()
 
   var httpOpts = self.httpOptions || {}
   if (httpOpts) {
@@ -150,45 +146,38 @@ Pushover.prototype.send = function (obj, fn) {
     o.protocol = proxy.protocol
   }
 
-  var request
-  if (httpOpts.proxy && httpOpts.proxy !== '') {
-    request = http.request
-  } else {
-    request = https.request
-  }
-
-  var req = request(o, function (res) {
-    if (self.debug) {
-      console.log(res.statusCode)
+  form.submit(o,function(err,res) {
+    if(err) {
+	    if (fn) {
+		    fn(err)
+	    }
+	    // In the tests the "end" event did not get emitted if  "error" was emitted,
+	    // but to be sure that the callback is not get called twice, null the callback function
+	    fn = null
     }
-    var err
-    var data = ''
-    res.on('end', function () {
-      self.errors(data, res)
-      if (fn) {
-        fn(err, data, res)
-      }
-    })
 
-    res.on('data', function (chunk) {
-      data += chunk
-    })
+	  if (self.debug) {
+		  console.log(res.statusCode)
+	  }
+
+	  var data = ''
+	  res.on('end', function () {
+		  self.errors(data, res)
+		  if (fn) {
+			  fn(err, data, res)
+		  }
+	  })
+
+	  res.on('data', function (chunk) {
+		  data += chunk
+	  })
   })
 
-  req.on('error', function (err) {
-    if (fn) {
-      fn(err)
-    }
-  // In the tests the "end" event did not get emitted if  "error" was emitted,
-  // but to be sure that the callback is not get called twice, null the callback function
-    fn = null
-  })
 
-  if (self.debug) {
-    console.log(reqString.replace(self.token, 'XXXXX').replace(self.user, 'XXXXX'))
-  }
-  req.write(reqString)
-  req.end()
+
+  // if (self.debug) {
+  //   console.log(form.replace(self.token, 'XXXXX').replace(self.user, 'XXXXX'))
+  // }
 }
 
 exports = module.exports = Pushover

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -123,6 +123,12 @@ Pushover.prototype.send = function (obj, fn) {
   form.append('token',self.token || obj.token)
   form.append('user',self.user || obj.user)
 
+	if('attachment' in obj && obj.attachment instanceof Buffer) {
+		// Sending a file from a buffer
+		// https://stackoverflow.com/a/43914175
+		form.append('attachment',obj.attachment,{filename: 'filename'})
+    delete obj.attachment
+	}
   var p
   for (p in obj) {
     form.append(p,obj[p])

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "type": "git",
     "url": "https://github.com/qbit/node-pushover.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "form-data": "^2.3.2"
+  },
   "devDependencies": {},
   "optionalDependencies": {},
   "engines": {

--- a/test/test_attachment.js
+++ b/test/test_attachment.js
@@ -1,0 +1,25 @@
+var Push = require('../lib/pushover.js')
+var fs = require('fs')
+
+var p = new Push({
+  user: process.env['PUSHOVER_USER'],
+  token: process.env['PUSHOVER_TOKEN'],
+  update_sounds: false,
+  debug: true
+})
+
+var msg = {
+  message: 'test from ' + process.argv[1],
+  sound: 'magic',
+  title: 'Well - this is fantastic',
+  attachment: fs.createReadStream('../img/pushover-header.png')
+}
+
+// console.log( p );
+
+p.send(msg, function (err, result, res) {
+  console.log('error', err)
+  console.log('result', result)
+  console.log('res.headers', res.headers)
+  // process.exit(0);
+})

--- a/test/test_attachment.js
+++ b/test/test_attachment.js
@@ -11,7 +11,7 @@ var p = new Push({
 var msg = {
   message: 'test from ' + process.argv[1],
   sound: 'magic',
-  title: 'Well - this is fantastic',
+  title: 'Testing attachment',
   attachment: fs.createReadStream('../img/pushover-header.png')
 }
 
@@ -23,3 +23,19 @@ p.send(msg, function (err, result, res) {
   console.log('res.headers', res.headers)
   // process.exit(0);
 })
+
+fs.readFile('../img/pushover-header.png', function (err, data) {
+  if (err) throw err;
+
+  msg = {
+    message: 'test from ' + process.argv[1],
+    title: 'Testing attachment from buffer',
+    attachment: data
+  }
+
+  p.send(msg, function (err, result, res) {
+    console.log('error', err)
+    console.log('result', result)
+    console.log('res.headers', res.headers)
+  })
+});

--- a/test/test_attachment.js
+++ b/test/test_attachment.js
@@ -12,7 +12,7 @@ var msg = {
   message: 'test from ' + process.argv[1],
   sound: 'magic',
   title: 'Testing attachment',
-  attachment: fs.createReadStream('../img/pushover-header.png')
+  attachment: fs.createReadStream('img/pushover-header.png')
 }
 
 // console.log( p );
@@ -24,7 +24,7 @@ p.send(msg, function (err, result, res) {
   // process.exit(0);
 })
 
-fs.readFile('../img/pushover-header.png', function (err, data) {
+fs.readFile('img/pushover-header.png', function (err, data) {
   if (err) throw err;
 
   msg = {


### PR DESCRIPTION
Hi @qbit 

This PR implements the [attachment feature](https://pushover.net/api#attachments) of the pushover API as per #20 so that you can send pushover messages with images.

The implementation uses the [form-data](https://www.npmjs.com/package/form-data) module to generate the `multipart/form-data` encoding.  The module is downloaded 10M weekly, is robust and succinct in implementation.

I've prepared tests to validate the new functionality, and existing tests still pass.

I've also updated the README with examples of how to send images with messages according to this PR.  Images can be provided using a ReadStream of a Buffer.

@qbit would you merge this PR into master?

Cheers,
Damo.