### PR TITLE
Don't crash when JSON parsing fails

### DIFF
--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -158,7 +158,7 @@ Pushover.prototype.updateSounds = function () {
         self.errors(data, res)
         self.sounds = j.sounds
       } catch (error) {
-        console.error('Pushover: parsing sound data failed', error)
+        self.errors('Pushover: parsing sound data failed', res)
       }
     })
 

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -153,9 +153,13 @@ Pushover.prototype.updateSounds = function () {
   var surl = 'https://api.pushover.net/1/sounds.json?token=' + self.token
   var req = https.request(url.parse(surl), function (res) {
     res.on('end', function () {
-      var j = JSON.parse(data)
-      self.errors(data, res)
-      self.sounds = j.sounds
+      try {
+        var j = JSON.parse(data)
+        self.errors(data, res)
+        self.sounds = j.sounds
+      } catch (error) {
+        console.error('Pushover: parsing sound data failed', error)
+      }
     })
 
     res.on('data', function (chunk) {

--- a/lib/pushover.js
+++ b/lib/pushover.js
@@ -131,7 +131,11 @@ function Pushover (opts) {
 
 Pushover.prototype.errors = function (d, res) {
   if (typeof d === 'string') {
-    d = JSON.parse(d)
+    try {
+      d = JSON.parse(d)
+    } catch (error) {
+      throw new Error('JSON parsing failed', res)
+    }
   }
 
   if (d.errors) {


### PR DESCRIPTION
Pushover has been under DDOS today and responds with a HTML page with a 5xx status code, which doesn't parse as JSON, resulting in this library crashing. This PR prevents that crash